### PR TITLE
Refacto languages

### DIFF
--- a/src/main/java/io/tvelu77/cloutmetrics/Utils.java
+++ b/src/main/java/io/tvelu77/cloutmetrics/Utils.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class Utils {
   
-  public static final Map<String, String> EXTENSION = new HashMap<>();
+  public static final Map<String, Language> EXTENSION = new HashMap<>();
   
   @Autowired
   private Environment env;
@@ -34,7 +34,7 @@ public class Utils {
       for (var language : languages) {
         if (language.getExtensions() != null) {
           for (var extension : language.getExtensions()) {
-            EXTENSION.putIfAbsent(extension, language.getName());
+            EXTENSION.putIfAbsent(extension, language);
           }
         }
       }

--- a/src/main/java/io/tvelu77/cloutmetrics/git/GitService.java
+++ b/src/main/java/io/tvelu77/cloutmetrics/git/GitService.java
@@ -42,31 +42,30 @@ public class GitService implements ApplicationService<Git> {
     metrics.setTotalCommits(0L);
     toBeSaved.setMetrics(metrics);
     gitRepository.save(toBeSaved);
-    try (var executor = Executors.newSingleThreadExecutor()) {
-      executor.submit(() -> {
-        try {
-          var operations = new MetricsOperations(git,
-                  Path.of(utils.getLocalRepositoryPath() + git.getName()));
-          operations.openRepository();
-          metrics.setOwner(operations.getGitOwner());
-          gitRepository.save(toBeSaved);
-          metrics.setTotalCommits(operations.countCommits());
-          gitRepository.save(toBeSaved);
-          metrics.setTotalTags(operations.countTags());
-          gitRepository.save(toBeSaved);
-          metrics.setTotalBranches(operations.countBranches());
-          gitRepository.save(toBeSaved);
-          metrics.setLanguageAndFileCount(operations.countFilesForEachExtension());
-          gitRepository.save(toBeSaved);
-          metrics.setLanguageRatio(operations.languageRatio());
-          gitRepository.save(toBeSaved);
-          operations.closeRepository();
-        } catch (GitAPIException | IOException e) {
-          System.out.println("error :" + e);
-          gitRepository.delete(git);
-        }
-      });
-    }
+    var executor = Executors.newSingleThreadExecutor();
+    executor.submit(() -> {
+      try {
+        var operations = new MetricsOperations(git,
+                Path.of(utils.getLocalRepositoryPath() + git.getName()));
+        operations.openRepository();
+        metrics.setOwner(operations.getGitOwner());
+        gitRepository.save(toBeSaved);
+        metrics.setTotalCommits(operations.countCommits());
+        gitRepository.save(toBeSaved);
+        metrics.setTotalTags(operations.countTags());
+        gitRepository.save(toBeSaved);
+        metrics.setTotalBranches(operations.countBranches());
+        gitRepository.save(toBeSaved);
+        metrics.setLanguageAndFileCount(operations.countFilesForEachExtension());
+        gitRepository.save(toBeSaved);
+        metrics.setLanguageRatio(operations.languageRatio());
+        gitRepository.save(toBeSaved);
+        operations.closeRepository();
+      } catch (GitAPIException | IOException e) {
+        System.out.println("error :" + e);
+        gitRepository.delete(git);
+      }
+    });
     return true;
   }
 

--- a/src/main/java/io/tvelu77/cloutmetrics/utils/Language.java
+++ b/src/main/java/io/tvelu77/cloutmetrics/utils/Language.java
@@ -1,5 +1,6 @@
 package io.tvelu77.cloutmetrics.utils;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import java.util.Objects;
@@ -11,7 +12,9 @@ import java.util.Objects;
 public class Language {
   
   private String name;
-  private String type;
+
+  private LanguageType type;
+
   private List<String> extensions;
   
   public String getName() {
@@ -22,11 +25,11 @@ public class Language {
     this.name = Objects.requireNonNull(name);
   }
   
-  public String getType() {
+  public LanguageType getType() {
     return type;
   }
   
-  public void setType(String type) {
+  public void setType(LanguageType type) {
     this.type = Objects.requireNonNull(type);
   }
   

--- a/src/main/java/io/tvelu77/cloutmetrics/utils/LanguageType.java
+++ b/src/main/java/io/tvelu77/cloutmetrics/utils/LanguageType.java
@@ -1,0 +1,27 @@
+package io.tvelu77.cloutmetrics.utils;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Defines an enum for the type of language.<br>
+ * It can be a :<br>
+ * - PROGRAMMING language ;<br>
+ * - MARKUP language ;<br>
+ * - DATA language ;<br>
+ * - PROSE language.
+ */
+public enum LanguageType {
+
+  @JsonProperty("programming")
+  PROGRAMMING,
+
+  @JsonProperty("markup")
+  MARKUP,
+
+  @JsonProperty("data")
+  DATA,
+
+  @JsonProperty("prose")
+  PROSE;
+
+}


### PR DESCRIPTION
Instead of using a string for the language type, we use an enum for better data handling